### PR TITLE
desktop notifications support

### DIFF
--- a/_attachments/index.html
+++ b/_attachments/index.html
@@ -62,6 +62,7 @@
                 </li>
                 <li ng-class="{active: $route.current.activetab == 'dashboard'}"><a href="#/dashboard/{{acralyzer.app}}">Dashboard</a></li>
                 <li ng-class="{active: $route.current.activetab == 'reports-browser'}"><a href="#/reports-browser/{{acralyzer.app}}">Reports browser</a></li>
+                <li notifications-support></li>
             </ul>
             <div id="account"></div>
 

--- a/_attachments/script/AcralyzerControllers.js
+++ b/_attachments/script/AcralyzerControllers.js
@@ -17,7 +17,7 @@
  along with Acralyzer.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-function AcralyzerCtrl($scope, ReportsStore, $rootScope) {
+function AcralyzerCtrl($scope, ReportsStore, $rootScope, desktopNotifications) {
     $scope.acralyzer = {
         apps: []
     };
@@ -60,6 +60,7 @@ function AcralyzerCtrl($scope, ReportsStore, $rootScope) {
     }
 
     var notifyNewData = function() {
+        desktopNotifications.notify({ title: "Acralyzer - " + $scope.acralyzer.app, body: "Received new report(s)", icon: null });
         $('.top-right').notify({
             message: { text: 'Received new report(s)' },
             type: 'warning'
@@ -67,5 +68,4 @@ function AcralyzerCtrl($scope, ReportsStore, $rootScope) {
     };
 
     $scope.$on("new data", notifyNewData);
-
 }

--- a/_attachments/script/app.js
+++ b/_attachments/script/app.js
@@ -93,6 +93,62 @@ acralyzer.directive('reportDetails', function() {
     };
 });
 
+acralyzer.factory('desktopNotifications', [function() {
+    /* data is an object with 'title', 'body' and optional 'icon' keys */
+    if ("Notification" in window && window.Notification.permissionLevel) {
+        return {
+            notify: function(data) {
+                if (Notification.permissionLevel() !== "granted") { return; }
+
+                var notif = new Notification(data.title, data);
+                notif.show();
+            }
+        };
+    }
+    else if (window.webkitNotifications) {
+        return {
+            notify: function(data) {
+                if (webkitNotifications.checkPermission()) { return; }
+
+                var notif = webkitNotifications.createNotification(data.icon, data.title, data.body);
+                notif.show();
+            }
+        };
+    }
+}]);
+
+acralyzer.directive('notificationsSupport', [function() {
+    return {
+        restrict: 'A',
+        link: function(scope,elm,attrs,controller) {
+            elm.addClass('btn');
+            elm.text("Desktop Notifications?");
+            if ("Notification" in window && window.Notification.permissionLevel) {
+                if (Notification.permissionLevel() === "default") {
+                    elm.on('click', function(ev) {
+                        Notification.requestPermission(function () {
+                            elm.remove();
+                        });
+                    });
+                    return;
+                }
+            }
+            else if (window.webkitNotifications) {
+                if (webkitNotifications.checkPermission() === 1) {
+                    elm.on('click', function(ev) {
+                        webkitNotifications.requestPermission(function () {
+                            elm.remove();
+                        });
+                    });
+                    return;
+                }
+            }
+            /* Not allowed or not supported */
+            elm.remove();
+        }
+    };
+}]);
+
 // TODO: migrate this code to angular logic
 ///////////////////////////////////
 // Apache 2.0 J Chris Anderson 2011


### PR DESCRIPTION
Add support for desktop notifications.

Chome needs the requesting of permissions to be an interactive event (click/keyboard) so i made i made an angular directive.

Works on my install of chrome and safari. Looks like there's a firefox addon to support the webkit api.

open to feedback if needed.
