### PR TITLE
remove formatting from directive and move it back to the html

### DIFF
--- a/_attachments/index.html
+++ b/_attachments/index.html
@@ -62,7 +62,7 @@
                 </li>
                 <li ng-class="{active: $route.current.activetab == 'dashboard'}"><a href="#/dashboard/{{acralyzer.app}}">Dashboard</a></li>
                 <li ng-class="{active: $route.current.activetab == 'reports-browser'}"><a href="#/reports-browser/{{acralyzer.app}}">Reports browser</a></li>
-                <li notifications-support></li>
+                <li class="btn" notifications-support>Desktop Notifications?</li>
             </ul>
             <div id="account"></div>
 

--- a/_attachments/script/app.js
+++ b/_attachments/script/app.js
@@ -131,8 +131,6 @@ acralyzer.directive('notificationsSupport', [function() {
     return {
         restrict: 'A',
         link: function(scope,elm,attrs,controller) {
-            elm.addClass('btn');
-            elm.text("Desktop Notifications?");
             if ("Notification" in window && window.Notification.permissionLevel) {
                 if (Notification.permissionLevel() === "default") {
                     elm.on('click', function(ev) {


### PR DESCRIPTION
Looks like I forgot to commit this before the pull request. Move the desktop notifications styling/text out of the directive and into the html.

This allows for the config to be somewhere other than the main toolbar.
