### PR TITLE
Remove non-working RSS <link> tag

### DIFF
--- a/_attachments/index.html
+++ b/_attachments/index.html
@@ -22,7 +22,6 @@
     <title>Acralyzer / {{acralyzer.app}}</title>
     <meta charset="utf-8">
     <link rel="icon" type="image/png" href="img/logo.png" />
-    <link rel="alternate" type="application/rss+xml"  href="{{rsslink}}" title="Latest Crash Reports">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <!-- build:css vendor/bootstrap/css/bootstrap.min.css -->


### PR DESCRIPTION
{{rsslink}} has been undefined since commit 63d1d956fbc (Fix RSS link).

I originally tried this change:

```
-    <link rel="alternate" type="application/rss+xml"  href="{{rsslink}}" title="Latest Crash Reports">
+    <link rel="alternate" type="application/rss+xml"  href="/acra-{{acralyzer.app}}/_design/acra-storage/_list/rss/recent-items?descending=true" title="Latest Crash Reports">
```

The substitution looked fine in the Firefox Inspector, but Firefox apparently parses the RSS URL too early during the page load process; clicking "Subscribe to this page" did nothing, and Tamper Data showed a GET request to `/acra-%7B%7Bacralyzer.app%7D%7D...`

Manually replacing {{acralyzer.app}} with my app's literal name made "Subscribe to this page" work again.

This page corroborates my claim that Firefox is picky about editing the `<link>` href from Javascript, and suggests a few other alternatives:

http://ask.metafilter.com/54377/Firefox-and-Javascript-issue
