### PR TITLE
Add support for URL prefixes

### DIFF
--- a/_attachments/script/AcralyzerControllers.js
+++ b/_attachments/script/AcralyzerControllers.js
@@ -131,7 +131,7 @@
         };
 
         // Check if hosting is Cloudant or older CouchDB version
-        $http({method : 'GET', url: '/'}).success(function(data){
+        $http({method : 'GET', url: acralyzerConfig.urlPrefix + '/'}).success(function(data){
             if(data.cloudant_build) {
                 $scope.acralyzer.cloudant = true;
                 acralyzer.cloudant = true;

--- a/_attachments/script/config.js
+++ b/_attachments/script/config.js
@@ -5,6 +5,7 @@
     acralyzerConfig.backgroundPollingOnStartup = true;
 
     acralyzerConfig.appDBPrefix = "acra-";
+    acralyzerConfig.urlPrefix = "";
 
     // Helper functions
 

--- a/_attachments/script/service.reportsstore.js
+++ b/_attachments/script/service.reportsstore.js
@@ -46,11 +46,11 @@
         */
         ReportsStore.setApp = function (newAppName, cb) {
             ReportsStore.dbName = acralyzerConfig.appDBPrefix + newAppName;
-            ReportsStore.views = $resource('/' + ReportsStore.dbName + '/_design/acra-storage/_view/:view');
-            ReportsStore.details = $resource('/' + ReportsStore.dbName + '/:reportid');
-            ReportsStore.bug = $resource('/' + ReportsStore.dbName + '/:bugid', { bugid: '@_id' }, { save: {method: 'PUT'}});
-            ReportsStore.dbstate = $resource('/' + ReportsStore.dbName + '/');
-            ReportsStore.changes = $resource('/' + ReportsStore.dbName + '/_changes');
+            ReportsStore.views = $resource(acralyzerConfig.urlPrefix + '/' + ReportsStore.dbName + '/_design/acra-storage/_view/:view');
+            ReportsStore.details = $resource(acralyzerConfig.urlPrefix + '/' + ReportsStore.dbName + '/:reportid');
+            ReportsStore.bug = $resource(acralyzerConfig.urlPrefix + '/' + ReportsStore.dbName + '/:bugid', { bugid: '@_id' }, { save: {method: 'PUT'}});
+            ReportsStore.dbstate = $resource(acralyzerConfig.urlPrefix + '/' + ReportsStore.dbName + '/');
+            ReportsStore.changes = $resource(acralyzerConfig.urlPrefix + '/' + ReportsStore.dbName + '/_changes');
             ReportsStore.lastseq = -1;
             cb();
         };
@@ -71,7 +71,7 @@
                 }
                 cb(finalData);
             };
-            $http.get('/_all_dbs').success(filterDbsCallback).error(errorHandler);
+            $http.get(acralyzerConfig.urlPrefix + '/_all_dbs').success(filterDbsCallback).error(errorHandler);
         };
 
         /**
@@ -353,7 +353,7 @@
                     console.log(doc);
                 }
                 console.log("Deleting " + docsToPurge.length + "reports.");
-                $http.post("/" + ReportsStore.dbName + "/_bulk_docs", { docs: docsToPurge })
+                $http.post(acralyzerConfig.urlPrefix + "/" + ReportsStore.dbName + "/_bulk_docs", { docs: docsToPurge })
                     .success(finalCallback);
             };
 
@@ -391,7 +391,7 @@
                     console.log(doc);
                 }
                 console.log("Deleting " + docsToPurge.length + "reports.");
-                $http.post("/" + ReportsStore.dbName + "/_bulk_docs", { docs: docsToPurge })
+                $http.post(acralyzerConfig.urlPrefix + "/" + ReportsStore.dbName + "/_bulk_docs", { docs: docsToPurge })
                     .success(finalCallback);
             };
 

--- a/_attachments/script/service.user.js
+++ b/_attachments/script/service.user.js
@@ -26,7 +26,7 @@
     * @static
     */
     acralyzer.service('$user', ['$rootScope', '$q', '$resource', '$http', function($rootScope, $q, $resource, $http) {
-        var SessionResource = $resource('/_session');
+        var SessionResource = $resource(acralyzerConfig.urlPrefix + '/_session');
         var UserResource;
         var acralyzerDbName = location.pathname.split("/")[1];
         var PreferencesResource = $resource("/" + acralyzerDbName + "/org.couchdb.user\\::name",
@@ -120,7 +120,7 @@
             /* Does this box support changing admin passwords */
             if ($user.username && $user.isAdmin && _hasAdminPath === undefined)
             {
-                $http.get('/_config/admins/' + $user.username)
+                $http.get(acralyzerConfig + '/_config/admins/' + $user.username)
                 .success(function(data, status, headers, config) {
                     if (data.match(/^"-hashed-/)) {
                         _hasAdminPath = true;
@@ -154,7 +154,7 @@
             var newSession = new SessionResource(data);
             */
             var _newSessionPromise = $http.post(
-                '/_session',
+                acralyzerConfig.urlPrefix + '/_session',
                 $.param(data),
                 {
                     headers: {
@@ -193,7 +193,7 @@
             }
 
             if ($user.isAdmin && _hasAdminPath === true) {
-                $http.put('/_config/admins/'+$user.username, JSON.stringify(password))
+                $http.put(acralyzerConfig.urlPrefix + '/_config/admins/'+$user.username, JSON.stringify(password))
                 .success(function() {
                     $user.logout();
                     deferred.resolve();
@@ -330,7 +330,7 @@
             $http(
                 {
                     method: 'PUT',
-                    url: '/_users/org.couchdb.user:' + login,
+                    url: acralyzerConfig.urlPrefix + '/_users/org.couchdb.user:' + login,
                     data: userData
                 }
             ).success(


### PR DESCRIPTION
Hi all,

we are proxying CouchDB through nginx in a subdirectory. Unlike Futon, acralyzer doesn't have support for URL prefixing. This change corrects this and allows users to set a URL prefix in the configuration file.

Thanks,
-ag