### PR TITLE
Fix build system by removing broken dependencies

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,14 +55,6 @@ module.exports = function (grunt) {
                 'test/spec/{,*/}*.js'
             ]
         },
-        mocha: {
-            all: {
-                options: {
-                    run: true,
-                    urls: ['http://localhost:<%= connect.options.port %>/index.html']
-                }
-            }
-        },
         compass: {
             options: {
                 sassDir: '<%= yeoman.app %>/styles',
@@ -205,9 +197,8 @@ module.exports = function (grunt) {
     });
 
     grunt.registerTask('test', [
-        'clean:server',
+        'clean:server'
 //        'compass',
-        'mocha'
     ]);
 
     grunt.registerTask('build', [

--- a/package.json
+++ b/package.json
@@ -14,10 +14,8 @@
     "grunt-contrib-cssmin": "~0.4.1",
     "grunt-contrib-clean": "0.4.0",
     "grunt-contrib-imagemin": "0.1.2",
-    "grunt-bower-hooks": "~0.2.0",
     "grunt-usemin": "~0.1.9",
     "grunt-regarde": "~0.1.1",
-    "grunt-mocha": "~0.2.2",
     "grunt-open": "~0.2.0",
     "matchdep": "~0.1.1",
     "grunt-contrib-compress": "~0.4.1"


### PR DESCRIPTION
Running `npm install` currently fails because `grunt-bower-hooks` has been unpublished from npm and `grunt-mocha` depends on an unavailable version of `phantomjs`. Both components are unused (`bower-hooks` entirely and `mocha` because there are no tests), so I removed them.